### PR TITLE
Private orgs

### DIFF
--- a/github_users.py
+++ b/github_users.py
@@ -48,7 +48,7 @@ class Application(object):
         # Find the organization with the given name
         # GOTCHA: Assumes the given name is exact and looks for a perfect match
         # GOTCHA: Assumes there is only 1 organization with the given name
-        org = [org for org in self._github.iter_orgs(login=self._me.login) if org.login == org_name][0]
+        org = [org for org in self._github.iter_orgs() if org.login == org_name][0]
 
         for user in org.iter_members():
             # For every user, grab the whole user object and yield

--- a/github_users.py
+++ b/github_users.py
@@ -17,7 +17,7 @@ CONTEXT_SETTINGS = {
 
 class Application(object):
     DEFAULT_FIELD_NAMES = ['name', 'login']
-    VERSION = '0.0.1'
+    VERSION = '0.0.2'
 
     def __init__(self, github_token):
         """

--- a/github_users.py
+++ b/github_users.py
@@ -17,6 +17,7 @@ CONTEXT_SETTINGS = {
 
 class Application(object):
     DEFAULT_FIELD_NAMES = ['name', 'login']
+    VERSION = '0.0.1'
 
     def __init__(self, github_token):
         """
@@ -185,6 +186,9 @@ class Application(object):
         'the names of the fields. If invalid field is listed, the values will be all empty string.'
         '(default: ' + str(Application.DEFAULT_FIELD_NAMES) + ')'
     )
+)
+@click.version_option(
+    version=Application.VERSION,
 )
 def main(org_name, github_token, output_format, output, field_names):
     """

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,11 @@
 
 from __future__ import absolute_import
 from setuptools import setup
+from github_users import Application
 
 
 # We use the version to construct the DOWNLOAD_URL.
-VERSION = '0.0.1'
+VERSION = Application.VERSION
 
 # URL to the repository on Github.
 REPO_URL = 'https://github.com/hanpeter/github-users'


### PR DESCRIPTION
## What does this PR do?
Removed `login` parameter in `iter_orgs()`. Cleaned up how version is being decided and added `--version` CLI option.

## Why is this change being made?
Using `login` parameter in `iter_orgs()` method means that only public organizations are displayed. Both public and private organizations should be used.

## How was this tested? How can the reviewer verify your testing?
The change was manually tested on development environment.